### PR TITLE
Prevent "undefined" money transfer reason.

### DIFF
--- a/qb-phone/client/main.lua
+++ b/qb-phone/client/main.lua
@@ -2322,6 +2322,7 @@ end)
 
 RegisterNetEvent('hud:client:OnMoneyChange', function(type, amount, isMinus, reason)
     if type == "bank" then
+        reason = reason or ""
         if isMinus then
             SendNUIMessage({
                 action = "ChangeMoney_Wenmo",


### PR DESCRIPTION
Prvent "undefined" as a reason for money transfer.
Eg:
https://cdn.discordapp.com/attachments/819858231089168394/951593169185800232/1.png